### PR TITLE
[cli] export AssetUtils

### DIFF
--- a/packages/cli/src/__tests__/index-test.ts
+++ b/packages/cli/src/__tests__/index-test.ts
@@ -1,0 +1,13 @@
+import * as CLI from '../index';
+
+describe('cli index', () => {
+  it('exports AssetUtils with the expected function names', () => {
+    expect(CLI.AssetUtils.filterPlatformAssetScales).toBeDefined();
+    expect(CLI.AssetUtils.getAndroidAssetSuffix).toBeDefined();
+    expect(CLI.AssetUtils.getAndroidResourceFolderName).toBeDefined();
+    expect(CLI.AssetUtils.getAndroidResourceIdentifier).toBeDefined();
+    expect(CLI.AssetUtils.getAssetDestPathAndroid).toBeDefined();
+    expect(CLI.AssetUtils.getAssetDestPathIOS).toBeDefined();
+    expect(CLI.AssetUtils.getBasePath).toBeDefined();
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,18 @@ import init from './commands/init/initCompat';
 import assertRequiredOptions from './tools/assertRequiredOptions';
 import loadConfig from './tools/config';
 
+import assetPathUtils from './commands/bundle/assetPathUtils';
+import filterPlatformAssetScales from './commands/bundle/filterPlatformAssetScales';
+import getAssetDestPathAndroid from './commands/bundle/getAssetDestPathAndroid';
+import getAssetDestPathIOS from './commands/bundle/getAssetDestPathIOS';
+
+const AssetUtils = {
+  ...assetPathUtils,
+  filterPlatformAssetScales,
+  getAssetDestPathAndroid,
+  getAssetDestPathIOS,
+};
+
 const pkgJson = require('../package.json');
 
 commander
@@ -244,4 +256,4 @@ async function setupAndRun() {
 
 const bin = require.resolve('./bin');
 
-export {run, init, bin};
+export {run, init, bin, AssetUtils};


### PR DESCRIPTION
(follow up to https://github.com/expo/expo/pull/8324#discussion_r426046050 and https://github.com/expo/expo/pull/8324#discussion_r426072845)

@brentvatne @ide I wanted to get your feedback on this before opening up an upstream PR.

Summary:
---------

In `expo-updates` we need to be able to, in native code, read a list of assets that have been embedded into a native binary. In order to do this effectively we need to be able to predictably take the list of assets output by Metro and find each asset in its embedded location.

Currently we vendor a number of utility methods used by the CLI to determine each asset's filename & location in the IPA/APK package, but this coupling is fragile. This PR exposes these utility methods in the external-facing API so that packages like `expo-updates` can depend directly on them.


Test Plan:
----------

Tested with a modified version of `expo-updates` that depends on these exported utils. The output of expo-updates' `createManifest` function was the same as before, as expected.
